### PR TITLE
adapt keyword regex to match dates with timezone, as in gcal

### DIFF
--- a/class.iCalReader.php
+++ b/class.iCalReader.php
@@ -198,7 +198,7 @@ class ICal
      */
     public function keyValueFromString($text)
     {
-        preg_match('/([A-Z-;=^:]+)[:]([\w\W]*)/', $text, $matches);
+        preg_match('/([A-Za-z-\/;=^:]+)[:]([\w\W]*)/', $text, $matches);
         if (count($matches) == 0) {
             return false;
         }


### PR DESCRIPTION
Google Calendar sometimes adds the timezone to dates, which then look like this:
````
DTSTART;TZID=Europe/Berlin:20141127T190000
````
These didn't match on the more specific regex, so I expanded it to match this.  Ideally, we would also parse the timezone, as a next step.