### PR TITLE
Fix issue where an event doesn't DTEND

### DIFF
--- a/class.iCalReader.php
+++ b/class.iCalReader.php
@@ -361,7 +361,12 @@ class ICal
                 $frequency = $rrules['FREQ'];
                 // Get Start timestamp
                 $start_timestamp = $this->iCalDateToUnixTimestamp($anEvent['DTSTART']);
-                $end_timestamp = $this->iCalDateToUnixTimestamp($anEvent['DTEND']);
+                if(isset($anEvent['DTEND'])) {
+                    $end_timestamp = $this->iCalDateToUnixTimestamp($anEvent['DTEND']);
+                }
+                else {
+                    $end_timestamp = $this->iCalDateToUnixTimestamp($anEvent['DTSTART']);
+                }
                 $event_timestamp_offset = $end_timestamp - $start_timestamp;
                 // Get Interval
                 $interval = (isset($rrules['INTERVAL']) && $rrules['INTERVAL'] != '') ? $rrules['INTERVAL'] : 1;


### PR DESCRIPTION
The parser stop parsing when an event doesn't have DTEND. This shouldn't stop the parsing the file since not all events should have end date time. The patch uses DTSTART when DTEND is not present.