### PR TITLE
Take into account inline timezones in DTSTART and DTEND

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ $ curl -s https://getcomposer.org/installer | php
 |`calendarDescription`    |-                                         |Returns the calendar description                                                                                             |
 |`calendarName`           |-                                         |Returns the calendar name                                                                                                    |
 |`calendarTimeZone`       |-                                         |Returns the calendar timezone                                                                                                |
-|`events`                 |-                                         |Returns an array of arrays with all events. Every event is an associative array and each property is an element it.          |
+|`events`                 |-                                         |Returns an array of EventObjects. Every event is a class with the event details being properties within it.                  |
 |`eventsFromRange`        |`$rangeStart = false`, `$rangeEnd = false`|Returns false when the current calendar has no events in range, else the events.                                             |
 |`freeBusyEvents`         |-                                         |Returns an array of arrays with all free/busy events. Every event is an associative array and each property is an element it.|
 |`hasEvents`              |-                                         |Returns a boolean value whether the current calendar has events or not                                                       |
 |`iCalDateToUnixTimestamp`|`$icalDate`                               |Return Unix timestamp from iCal date time format                                                                             |
 |`iCalDateWithTimeZone`   |`$event`, `$key`                          |Return a date adapted to the calendar timezone depending on the event TZID                                                   |
-|`processDateConversions` |-                                         |Processes date conversions using the timezone                                                                                |
+|`processDateConversions` |-                                         |Add fields `DTSTART_tz` and `DTEND_tz` to each event                                                                         |
+|`processDates`           |-                                         |Adds a unix timestamp to all `DT{START|END}_array` arrays                                                                    |
 |`processRecurrences`     |-                                         |Processes recurrence rules                                                                                                   |
-|`sortEventsWithOrder`    |`$events`, `$sortOrder = SORT_ASC`        |Sort events based on the given sort order                                                                                    |
+|`sortEventsWithOrder`    |`$events`, `$sortOrder = SORT_ASC`        |Sort events based on a given sort order                                                                                      |
 
 --
 

--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -517,7 +517,7 @@ class ICal
             foreach (array("DTSTART", "DTEND") as $type) {
                 if (isset($anEvent[$type])) {
                     $date = $anEvent[$type . "_array"][1];
-                    if ($anEvent[$type . "_array"][0]["TZID"]) {
+                    if (isset($anEvent[$type . "_array"][0]["TZID"])) {
                         $date = "TZID=" . $anEvent[$type . "_array"][0]["TZID"] . ":" . $date;
                     }
                     $events[$key][$type . "_array"][] = $this->iCalDateToUnixTimestamp($date);

--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -823,7 +823,7 @@ class ICal
                                 }
 
                                 if ($eventStartTimestamp > $startTimestamp && $eventStartTimestamp < $until) {
-                                    $anEvent['DTSTART'] = gmdate(self::DATE_FORMAT, $eventStartTimestamp) . '\T' . $startTime . 'Z';
+                                    $anEvent['DTSTART'] = gmdate(self::DATE_FORMAT, $eventStartTimestamp) . 'T' . $startTime . 'Z';
                                     $anEvent['DTSTART_array'] = array(array(), $anEvent['DTSTART'], $eventStartTimestamp);
                                     $anEvent['DTEND_array'] = $anEvent['DTSTART_array'];
                                     $anEvent['DTEND_array'][2] += $eventTimestampOffset;
@@ -874,7 +874,7 @@ class ICal
                                 $eventStartTimestamp = strtotime($eventStartDesc);
 
                                 if ($eventStartTimestamp > $startTimestamp && $eventStartTimestamp < $until) {
-                                    $anEvent['DTSTART'] = gmdate(self::DATE_FORMAT, $eventStartTimestamp) . '\T' . $startTime . 'Z';
+                                    $anEvent['DTSTART'] = gmdate(self::DATE_FORMAT, $eventStartTimestamp) . 'T' . $startTime . 'Z';
                                     $anEvent['DTSTART_array'] = array(array(), $anEvent['DTSTART'], $eventStartTimestamp);
                                     $anEvent['DTEND_array'] = $anEvent['DTSTART_array'];
                                     $anEvent['DTEND_array'][2] += $eventTimestampOffset;
@@ -923,7 +923,7 @@ class ICal
                                 $eventStartTimestamp = strtotime($eventStartDesc);
 
                                 if ($eventStartTimestamp > $startTimestamp && $eventStartTimestamp < $until) {
-                                    $anEvent['DTSTART'] = gmdate(self::DATE_FORMAT, $eventStartTimestamp) . '\T' . $startTime . 'Z';
+                                    $anEvent['DTSTART'] = gmdate(self::DATE_FORMAT, $eventStartTimestamp) . 'T' . $startTime . 'Z';
                                     $anEvent['DTSTART_array'] = array(array(), $anEvent['DTSTART'], $eventStartTimestamp);
                                     $anEvent['DTEND_array'] = $anEvent['DTSTART_array'];
                                     $anEvent['DTEND_array'][2] += $eventTimestampOffset;

--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -67,7 +67,7 @@ class ICal
 
     const DATE_FORMAT = 'Ymd';
     const TIME_FORMAT = 'His';
-    const DATE_TIME_FORMAT = self::DATE_FORMAT . '\T' . self::TIME_FORMAT;
+    const DATE_TIME_FORMAT = 'Ymd\THis';
 
     protected $dayOrdinals = array(
         1 => 'first',
@@ -514,13 +514,13 @@ class ICal
         }
 
         foreach ($events as $key => $anEvent) {
-            foreach (array("DTSTART", "DTEND") as $type) {
+            foreach (array('DTSTART', 'DTEND') as $type) {
                 if (isset($anEvent[$type])) {
-                    $date = $anEvent[$type . "_array"][1];
-                    if (isset($anEvent[$type . "_array"][0]["TZID"])) {
-                        $date = "TZID=" . $anEvent[$type . "_array"][0]["TZID"] . ":" . $date;
+                    $date = $anEvent[$type . '_array'][1];
+                    if (isset($anEvent[$type . '_array'][0]['TZID'])) {
+                        $date = 'TZID=' . $anEvent[$type . '_array'][0]['TZID'] . ':' . $date;
                     }
-                    $events[$key][$type . "_array"][] = $this->iCalDateToUnixTimestamp($date);
+                    $events[$key][$type . '_array'][] = $this->iCalDateToUnixTimestamp($date);
                 }
             }
         }


### PR DESCRIPTION
Fixes #77 by storing a properly generated unix timestamp in the `dtstart_array` and `dtend_array` properties and referring to that, rather than repeatedly generating it.

Also switches use of `date()` for `gmdate()`, as `date()` expects a unix timestamp and formats it into a *local* date - that is to say, automatically translates it into the local timezone of the server the script is running on; whilst `gmdate()`keeps it as UTC.