### PR TITLE
Return events from a range, for real

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ curl -s https://getcomposer.org/installer | php
 |`calendarName`           |-                                         |Returns the calendar name                                                                                                    |
 |`calendarTimeZone`       |-                                         |Returns the calendar timezone                                                                                                |
 |`events`                 |-                                         |Returns an array of EventObjects. Every event is a class with the event details being properties within it.                  |
-|`eventsFromRange`        |`$rangeStart = false`, `$rangeEnd = false`|Returns false when the current calendar has no events in range, else the events.                                             |
+|`eventsFromRange`        |`$rangeStart = false`, `$rangeEnd = false`|Returns a sorted array of the events in a given range, or false if no events exist in the range.                             |
 |`freeBusyEvents`         |-                                         |Returns an array of arrays with all free/busy events. Every event is an associative array and each property is an element it.|
 |`hasEvents`              |-                                         |Returns a boolean value whether the current calendar has events or not                                                       |
 |`iCalDateToUnixTimestamp`|`$icalDate`                               |Return Unix timestamp from iCal date time format                                                                             |

--- a/examples/index.php
+++ b/examples/index.php
@@ -4,7 +4,7 @@ require_once '../vendor/autoload.php';
 use ICal\ICal;
 
 $ical = new ICal('MyCal.ics');
-$events = $ical->events();
+
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -27,9 +27,42 @@ $events = $ical->events();
             The number of todos
         </li>
     </ul>
+
+    <h4>Events March through April:</h4>
     <div class="row">
     <?php
+    $events = $ical->eventsFromRange('2016-03-01', '2016-04-31');
     foreach ($events as $event) : ?>
+        <div class="col-sm-6 col-md-4">
+            <div class="thumbnail">
+                <div class="caption">
+                    <h3><?php echo $event->summary . ' (' . date('d-m-Y H:i', $ical->iCalDateToUnixTimestamp($event->dtstart)) . ')' ?></h3>
+                    <p>SUMMARY: <?php echo $event->summary ?></p>
+                    <p>DTSTART: <?php echo $event->dtstart ?></p>
+                    <p>DTEND: <?php echo $event->dtend ?></p>
+                    <p>DURATION: <?php echo $event->duration ?></p>
+                    <p>DTSTAMP: <?php echo $event->dtstamp ?></p>
+                    <p>UID: <?php echo $event->uid ?></p>
+                    <p>CREATED: <?php echo $event->created ?></p>
+                    <p>LAST-MODIFIED: <?php echo $event->lastmodified ?></p>
+                    <p>DESCRIPTION: <?php echo $event->description ?></p>
+                    <p>LOCATION: <?php echo $event->location ?></p>
+                    <p>SEQUENCE: <?php echo $event->sequence ?></p>
+                    <p>STATUS: <?php echo $event->status ?></p>
+                    <p>TRANSP: <?php echo $event->transp ?></p>
+                    <p>ORGANIZER: <?php echo $event->organizer ?></p>
+                    <p>ATTENDEE(S): <?php echo $event->attendee ?></p>
+                </div>
+            </div>
+        </div>
+    <?php endforeach ?>
+    </div>
+
+    <h4>All Events:</h4>
+    <div class="row">
+    <?php
+        $events = $ical->events();
+        foreach ($events as $event) : ?>
         <div class="col-sm-6 col-md-4">
             <div class="thumbnail">
                 <div class="caption">


### PR DESCRIPTION
Currently, if one tries to use `eventsFromRange`, it will return either `false` or an empty array. This is down to a misplaced negation on line 1093.

Looking at the code history, the line in question used to read `if (!$events)`, but was changed to `if (!empty($events))`. Whilst it was correct to add a check to see if the array is empty, the negating exclamation mark should have been removed. As it stands, the current code will return `false` when there *are* events, the opposite of what's intended.

I've also added an empty check on `$extendedEvents` to fulfil the function's descriptive comment of returning `false` when no events are found in the range; and a couple of `try...catch`s to deal with invalid input.